### PR TITLE
Enabled 'left' and 'right' actions to rotate horizontally in month view and week view.

### DIFF
--- a/autoload/calendar/constructor/view_days.vim
+++ b/autoload/calendar/constructor/view_days.vim
@@ -564,9 +564,9 @@ function! s:instance.action(action) dict
   let hour = b:calendar.time().hour()
   let wnum = d.sub(self.get_min_day())
   if a:action ==# 'left'
-    call b:calendar.move_day(get(self, 'stopend') ? max([-v:count1, -wnum]) : -v:count1)
+    call b:calendar.move_day(get(self, 'stopend') ? (-v:count1 % 7 < -wnum ? 7 - v:count1 % 7 : -v:count1 % 7) : -v:count1)
   elseif a:action ==# 'right'
-    call b:calendar.move_day(get(self, 'stopend') ? min([v:count1, -wnum + self.daynum - 1]) : v:count1)
+    call b:calendar.move_day(get(self, 'stopend') ? (v:count1 % 7 > -wnum + self.daynum -1 ? -7 + v:count1 % 7 : v:count1 % 7) : v:count1)
   elseif index(['prev', 'next', 'space', 'add', 'subtract'], a:action) >= 0
     call b:calendar.move_day(v:count1 * (index(['prev', 'subtract'], a:action) >= 0 ? -1 : 1))
   elseif index(['down', 'up'], a:action) >= 0

--- a/autoload/calendar/view/month.vim
+++ b/autoload/calendar/view/month.vim
@@ -307,9 +307,9 @@ function! s:self.action(action) dict
   let hwnum = calendar#week#week_number(hday)
   let lwnum = calendar#week#week_number(lday)
   if a:action ==# 'left'
-    call b:calendar.move_day(max([-v:count1, -wnum]))
+    call b:calendar.move_day(-v:count1 % 7 < -wnum ? 7 - v:count1 % 7 : -v:count1 % 7)
   elseif a:action ==# 'right'
-    call b:calendar.move_day(min([v:count1, -wnum + 6]))
+    call b:calendar.move_day(v:count1 % 7 > -wnum + 6 ? -7 + v:count1 % 7 : v:count1 % 7)
   elseif index(['prev', 'next', 'space', 'add', 'subtract'], a:action) >= 0
     call b:calendar.move_day(v:count1 * (index(['prev', 'subtract'], a:action) >= 0 ? -1 : 1))
   elseif index(['down', 'up'], a:action) >= 0


### PR DESCRIPTION
month view と week view の `h` と `l` でカーソルが週内でローテートするようにすると便利ではないかと考え，実装してみました．例えば，2014 / 1 / 6 にカーソルがあるとして，そこで `h` を押すと 2014 / 1 / 12 に移動します．

便利だと感じた理由は単純で，`hjkl` で移動（たいていのユーザはそうするでしょう）しているときに，カレンダーの端から逆の端に移動できたほうがカーソルの移動性が上がるからです．
おそらく，`w` や `b` も組み合わせてカーソルを移動することを想定されているのだと思うのですが，`hjkl` だけでカーソルを動かしたいユーザも多いと思います．
反面，`h` や `l` でカーソルが端に来た時にカーソルが止まって嬉しいことが特に思いつかなかったので，デフォルトの挙動を変更する実装としてみました．

もしよろしければ，ご検討お願いします．
