### PR TITLE
add missing calendar-syntax doc

### DIFF
--- a/doc/calendar.txt
+++ b/doc/calendar.txt
@@ -16,7 +16,7 @@ Options					|calendar-options|
 View					|calendar-view|
 Key Mappings				|calendar-key-mappings|
 Marks					|calendar-marks|
-Syntax					|calendar-syntax|
+Input Format				|calendar-input-format|
 Troubleshooting				|calendar-troubleshooting|
 Changelog				|calendar-changelog|
 
@@ -637,17 +637,19 @@ g'{a-z}  g`{a-z}	Jump to the mark {a-z}.
 :delm[arks]!		Delete all the marks.
 
 ------------------------------------------------------------------------------
-SYNTAX						*calendar-syntax*
+INPUT FORMAT					*calendar-input-formt*
 
 Calendar:
 	day event:
 		EVENT: event title
-	few hour event:
+	few hours event:
 		EVENT: 12:00-14:00 event title
 	few days event:
-		???
-	event with notes:
-		???
+		EVENT: 10/10-10/12 event title
+		EVENT: 2014/10/10-2014/10/12 event title
+		EVENT: 2014-10-10-2014-10-12 event title
+		EVENT: 10/10 19:00-10/11 21:00 event title
+		EVENT: 10/10/2014 19:00-10/11/2014 21:00 event title
 
 Task:
 	simple task:


### PR DESCRIPTION
Syntax documentation is listed in the documentation content but not present

this is a starting point based on what I found, but I missed some points
- how to create a few days event (example: from 2014-10-10 to 2014-10-12), and is it possible to specified starting and finishing hours for this kind of events?
- is it possible to add notes to event?

extra question:
- is it possible to see event notes directly in the vim interface?

btw, thanks a lot this is a realy good plugin ;-)
