### PR TITLE
Include keepalt when opening the calendar window

### DIFF
--- a/autoload/calendar/argument.vim
+++ b/autoload/calendar/argument.vim
@@ -244,8 +244,8 @@ function! calendar#argument#parse(args)
   elseif command ==# 'vnew' && width > 0
     let command = width . ' ' . command
   endif
-  let cmd1 = commandprefix . command . (addname ? name : '')
-  let cmd2 = 'edit' . name
+  let cmd1 = 'keepalt '. commandprefix . command . (addname ? name : '')
+  let cmd2 = 'keepalt edit' . name
   let command = 'if isnewbuffer | ' . cmd1 . ' | else | ' . cmd2 . '| endif'
   if flg_ymd
     let ymd = [arg_year, arg_month, arg_day, flg_year, flg_month, flg_day]


### PR DESCRIPTION
Sometimes I get confused when the alternate file is changed after checking the calendar. 

Example:

    nmap <silent> <Leader>cal :Calendar -view=year -split=vertical
             \ -position=topleft -width=27<CR>

`:e fileA`, `e: fileB`, `<c-^>` (ends in fileA), `<leader>cal`, `q`, `<c-^>` (ends in calendar buffer instead of fileB)