### PR TITLE
Calendar custom colors

### DIFF
--- a/doc/calendar.txt
+++ b/doc/calendar.txt
@@ -14,6 +14,7 @@ Vim application				|calendar-vim-application|
 Commands				|calendar-commands|
 Options					|calendar-options|
 View					|calendar-view|
+Colors					|calendar-colors|
 Key Mappings				|calendar-key-mappings|
 Marks					|calendar-marks|
 Input Format				|calendar-input-format|
@@ -495,6 +496,63 @@ This application has some different views. You can switch views with |>| and
 7. Event view					*calendar-view-event*
 	This view shows a event list. There are two available event views:
 	'event' and 'agenda'.
+
+------------------------------------------------------------------------------
+COLORS						*calendar-colors*
+
+In some cases default colors looks unreadable. So the application provides
+several variables to set your custom colors.
+
+1. Text color of work days and clock		*g:calendar_fg_color*
+	This variable allows to control color of clock and labels of work days
+	in the calendar.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_fg_color = {color_code}
+
+2. Background color of work days labels		*g:calendar_bg_color*
+	This variable allows to control color of background of work days label.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_bg_color = {color_code}
+
+3. Text color of comments			*g:calendar_comment_fg_color*
+	This variable allows to control text color of comments.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_comment_fg_color = {color_code}
+
+4. Color of selection				*g:calendar_select_color*
+	This variable allows to control color of selection.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_select_color = {color_code}
+
+5. Text color of Sunday				*g:calendar_sunday_fg_color*
+	This variable allows to control text color of Sunday label.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_sunday_fg_color = {color_code}
+
+6. Text color of Saturday			*g:calendar_saturday_fg_color*
+	This variable allows to control text color of Saturday label.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_saturday_fg_color = {color_code}
+
+7. Background color of Sunday			*g:calendar_sunday_bg_color*
+	This variable allows to control background color of Sunday label.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_sunday_bg_color = {color_code}
+
+8. Background color of Saturday			*g:calendar_saturday_bg_color*
+	This variable allows to control background color of Saturday label.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_saturday_bg_color = {color_code}
+
+9. Text color of today				*g:calendar_today_fg_color*
+	This variable allows to control text color of today.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_today_fg_color = {color_code}
+
+10. Background color of today			*g:calendar_today_color*
+	This variable allows to control background color of today.
+	For changing default color, declare this variable in your vimrc:
+	let g:calendar_today_color = {color_code}
 
 ------------------------------------------------------------------------------
 KEY MAPPINGS					*calendar-key-mappings*

--- a/syntax/calendar.vim
+++ b/syntax/calendar.vim
@@ -73,6 +73,18 @@ if !s:is_win32cui
   let s:saturday_title_fg_color = calendar#color#gen_color(s:saturday_fg_color, s:saturday_bg_color, 3, 1)
 endif
 
+let s:fg_color = get(g:, 'calendar_fg_color', s:fg_color)
+let s:bg_color = get(g:, 'calendar_bg_color', s:bg_color)
+let s:comment_fg_color = get(g:, 'calendar_comment_fg_color', s:comment_fg_color)
+let s:select_color = get(g:, 'calendar_select_color', s:select_color)
+
+let s:sunday_fg_color = get(g:, 'calendar_sunday_fg_color', s:sunday_fg_color)
+let s:saturday_fg_color = get(g:, 'calendar_saturday_fg_color', s:saturday_fg_color)
+let s:sunday_bg_color = get(g:, 'calendar_sunday_bg_color', s:sunday_bg_color)
+let s:saturday_bg_color = get(g:, 'calendar_saturday_bg_color', s:saturday_bg_color)
+let s:today_fg_color = get(g:, 'calendar_today_fg_color', s:today_fg_color)
+let s:today_color = get(g:, 'calendar_today_color', s:today_color)
+
 call calendar#color#syntax('Select', '', s:select_color, '')
 call calendar#color#syntax('Sunday', s:sunday_fg_color, s:sunday_bg_color, '')
 call calendar#color#syntax('Saturday', s:saturday_fg_color, s:saturday_bg_color, '')

--- a/syntax/calendar.vim
+++ b/syntax/calendar.vim
@@ -21,6 +21,9 @@ let s:select_color = calendar#color#gen_color(s:fg_color, s:bg_color, 1, 4)
 let s:is_win32cui = (has('win32') || has('win64')) && !has('gui_running')
 let s:is_dark = &background ==# 'dark'
 
+let s:fg_color = get(g:, 'calendar_fg_color', s:fg_color)
+let s:bg_color = get(g:, 'calendar_bg_color', s:bg_color)
+
 if !has('gui_running')
   if s:is_win32cui
     if s:is_dark
@@ -73,11 +76,8 @@ if !s:is_win32cui
   let s:saturday_title_fg_color = calendar#color#gen_color(s:saturday_fg_color, s:saturday_bg_color, 3, 1)
 endif
 
-let s:fg_color = get(g:, 'calendar_fg_color', s:fg_color)
-let s:bg_color = get(g:, 'calendar_bg_color', s:bg_color)
 let s:comment_fg_color = get(g:, 'calendar_comment_fg_color', s:comment_fg_color)
 let s:select_color = get(g:, 'calendar_select_color', s:select_color)
-
 let s:sunday_fg_color = get(g:, 'calendar_sunday_fg_color', s:sunday_fg_color)
 let s:saturday_fg_color = get(g:, 'calendar_saturday_fg_color', s:saturday_fg_color)
 let s:sunday_bg_color = get(g:, 'calendar_sunday_bg_color', s:sunday_bg_color)


### PR DESCRIPTION
Sometimes default colors is unreadable. I added possibility to change default colors. Please, see screenshots below.
Before my patch with default colors:
![calendar_before](https://cloud.githubusercontent.com/assets/5525113/25386711/f4ec6d64-29d0-11e7-9261-d1b47a93d948.png)
After my patch with custom colors:
![calendar_after](https://cloud.githubusercontent.com/assets/5525113/25386726/05fc5984-29d1-11e7-89fc-f3cd946a8ff1.png)


