### PR TITLE
strip proxy connect header

### DIFF
--- a/autoload/calendar/webapi.vim
+++ b/autoload/calendar/webapi.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/calendar/webapi.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2019/11/29 11:47:09.
+" Last Change: 2019/12/03 12:48:49.
 " =============================================================================
 
 " Web interface.
@@ -147,7 +147,7 @@ endfunction
 function! s:command(url, method, header, postfile, output) abort
   let quote = s:_quote()
   if executable('curl')
-    let command = 'curl --http1.1 -s -k -i -N -X ' . a:method
+    let command = 'curl --http1.1 --suppress-connect-headers -s -k -i -N -X ' . a:method
     let command .= s:make_header_args(a:header, '-H ', quote)
     if a:postfile !=# ''
       let command .= ' --data-binary @' . quote . a:postfile . quote


### PR DESCRIPTION
`curl` outputs the proxy connect header, using `--suppress-connect-headers` to strip it.