### PR TITLE
Add installation example using vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ itchyny (https://github.com/itchyny)
 This software is released under the MIT License, see LICENSE.
 
 ## Installation
-Install with your favorite plugin manager.
+Install with your favorite plugin manager.   
+Example installation using vim-plug: 
+
+Add the following line in your ~/.vimrc
+```
+Plug 'itchyny/calendar.vim'
+```
 
 ## Google Calendar and Google Task
 In order to view and edit calendars on Google Calendar, or task on Google Task,


### PR DESCRIPTION
It's not a big deal but usually vim plugin repositories give you an Example how to install plugin using vim-plug and it's much easier to copy a line from README :blush: 
